### PR TITLE
add correct configuration for fluentd v1.0 plugin

### DIFF
--- a/conf/fluent.conf
+++ b/conf/fluent.conf
@@ -8,26 +8,27 @@
   endpoint_url "#{ENV['LOGZIO_URL']}?token=#{ENV['LOGZIO_TOKEN']}"
   output_include_time true
   output_include_tags true
-
-  # Set the buffer type to file to improve the reliability and reduce the memory consumption
-  buffer_type file
-  buffer_path /var/log/fluentd-buffers/stackdriver.buffer
-  # Set queue_full action to block because we want to pause gracefully
-  # in case of the off-the-limits load instead of throwing an exception
-  buffer_queue_full_action block
-  # Set the chunk limit conservatively to avoid exceeding the GCL limit
-  # of 10MiB per write request.
-  buffer_chunk_limit 2M
-  # Cap the combined memory usage of this buffer and the one below to
-  # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-  buffer_queue_limit 6
-  # Never wait more than 5 seconds before flushing logs in the non-error case.
-  flush_interval 5s
-  # Never wait longer than 30 seconds between retries.
-  max_retry_wait 30
-  # Disable the limit on the number of retries (retry forever).
-  # disable_retry_limit
-  # Use multiple threads for processing.
-  num_threads 2
+  <buffer>
+    # Set the buffer type to file to improve the reliability and reduce the memory consumption
+    @type file
+    path /var/log/fluentd-buffers/stackdriver.buffer
+    # Set queue_full action to block because we want to pause gracefully
+    # in case of the off-the-limits load instead of throwing an exception
+    overflow_action block
+    # Set the chunk limit conservatively to avoid exceeding the GCL limit
+    # of 10MiB per write request.
+    chunk_limit_size 2M
+    # Cap the combined memory usage of this buffer and the one below to
+    # 2MiB/chunk * (6 + 2) chunks = 16 MiB
+    queue_limit_length 6
+    # Never wait more than 5 seconds before flushing logs in the non-error case.
+    flush_interval 5s
+    # Never wait longer than 30 seconds between retries.
+    retry_max_interval 30
+    # Disable the limit on the number of retries (retry forever).
+    retry_forever true
+    # Use multiple threads for processing.
+    flush_thread_count 2
+  </buffer>
 </match>
 


### PR DESCRIPTION
The current configuration for the logz.io output plugin is still in the fluentd v0.12 format. This fixes it to work for fluentd v1.x, as was done in the PR [fluentd-kubernetes-daemonset#231](https://github.com/fluent/fluentd-kubernetes-daemonset/pull/231), which appears to be the source of this repository.

This is based on the documentation for [fluentd-plugin-logzio](https://github.com/logzio/fluent-plugin-logzio).