### PR TITLE
Removed `'` from literal secret creation example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Replace `<<SHIPPING-TOKEN>>` with the [token](https://app.logz.io/#/dashboard/se
 Replace `<<LISTENER-HOST>>` with your region’s listener host (for example, listener.logz.io). For more information on finding your account’s region, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html).
 
 ```
-kubectl create secret generic logzio-logs-secret --from-literal=logzio-log-shipping-token='<<ACCOUNT-TOKEN>>' --from-literal=logzio-log-listener='https://<<LISTENER-HOST>>:8071' -n kube-system
+kubectl create secret generic logzio-logs-secret --from-literal=logzio-log-shipping-token=<<ACCOUNT-TOKEN>> --from-literal=logzio-log-listener=https://<<LISTENER-HOST>>:8071 -n kube-system
 ```
 
 Then you can easily install the DaemonSet on your cluster:


### PR DESCRIPTION
The `'` characters are stored as `'` in the secret, making the plugin output the following error:

> [error]: #0 unexpected error error_class=URI::InvalidURIError error="bad URI(is not URI?): 'https://listener-eu.logz.io:8071'?token='TOKEN'"

Removing them starts the container fine.