### PR TITLE
Update the ConfigMap

### DIFF
--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -112,7 +112,7 @@ data:
     <match **>
       @type logzio_buffered
       @id out_logzio
-      endpoint_url "#{ENV['LOGZIO_LOG_LISTENER']}?token=#{ENV['LOGZIO_LOG_SHIPPING_TOKEN']"
+      endpoint_url "#{ENV['LOGZIO_LOG_LISTENER']}?token=#{ENV['LOGZIO_LOG_SHIPPING_TOKEN']}"
       output_include_time true
       output_include_tags true
       <buffer>


### PR DESCRIPTION
There is a missing } in the token environment variable and without this, it will caused container to have oomkilled without log to help users to debug the problem.