### PR TITLE
update fluentd + logzio plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
-gem "fluentd", "1.3.3"
+gem "fluentd", "1.7.3"
 gem "oj", "3.5.1"
 gem "fluent-plugin-concat"
-gem "fluent-plugin-logzio"
+gem "fluent-plugin-logzio", "0.0.20"
 gem "fluent-plugin-record-modifier"
 gem "fluent-plugin-detect-exceptions"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    cool.io (1.5.3)
+    concurrent-ruby (1.1.5)
+    cool.io (1.5.4)
     dig_rb (1.0.1)
-    fluent-plugin-concat (2.3.0)
+    fluent-plugin-concat (2.4.0)
       fluentd (>= 0.14.0, < 2)
-    fluent-plugin-detect-exceptions (0.0.12)
+    fluent-plugin-detect-exceptions (0.0.13)
       fluentd (>= 0.10)
-    fluent-plugin-logzio (0.0.19)
+    fluent-plugin-logzio (0.0.20)
       fluentd (>= 0.14.0, < 2)
       net-http-persistent (~> 2.9)
     fluent-plugin-record-modifier (2.0.1)
       fluentd (>= 1.0, < 2)
-    fluentd (1.3.3)
+    fluentd (1.7.3)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
-      msgpack (>= 0.7.0, < 2.0.0)
+      msgpack (>= 1.2.0, < 2.0.0)
       serverengine (>= 2.0.4, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.2, < 1.0.0)
-      tzinfo (~> 1.0)
+      tzinfo (~> 2.0)
       tzinfo-data (~> 1.0)
       yajl-ruby (~> 1.0)
     http_parser.rb (0.6.0)
-    msgpack (1.2.6)
+    msgpack (1.3.1)
     net-http-persistent (2.9.4)
     oj (3.5.1)
-    serverengine (2.1.0)
+    serverengine (2.2.0)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2018.9)
+    tzinfo (2.0.0)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2019.3)
       tzinfo (>= 1.0.0)
     yajl-ruby (1.4.1)
 
@@ -44,10 +44,10 @@ PLATFORMS
 DEPENDENCIES
   fluent-plugin-concat
   fluent-plugin-detect-exceptions
-  fluent-plugin-logzio
+  fluent-plugin-logzio (= 0.0.20)
   fluent-plugin-record-modifier
-  fluentd (= 1.3.3)
+  fluentd (= 1.7.3)
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
Without updating these, the `logzio/logzio-k8s:latest` image fails with the following stacktrace;

```
2019-11-23 03:33:06 +0000 [warn]: #0 [out_logzio] got unrecoverable error in primary and no secondary error_class=NoMethodError error="undefined method `request_uri' for #<URI::Generic ?token=>"
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluent-plugin-logzio-0.0.20/lib/fluent/plugin/out_logzio_buffered.rb:127:in `send_bulk'
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluent-plugin-logzio-0.0.20/lib/fluent/plugin/out_logzio_buffered.rb:81:in `block in write'
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluent-plugin-logzio-0.0.20/lib/fluent/plugin/out_logzio_buffered.rb:119:in `encode_chunk'
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluent-plugin-logzio-0.0.20/lib/fluent/plugin/out_logzio_buffered.rb:80:in `write'
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluentd-1.7.3/lib/fluent/plugin/output.rb:1125:in `try_flush'
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluentd-1.7.3/lib/fluent/plugin/output.rb:1431:in `flush_thread_run'
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluentd-1.7.3/lib/fluent/plugin/output.rb:461:in `block (2 levels) in start'
  2019-11-23 03:33:06 +0000 [warn]: #0 /fluentd/vendor/bundle/ruby/2.6.0/gems/fluentd-1.7.3/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```