### PR TITLE
1.16 fix

### DIFF
--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -36,7 +36,7 @@ subjects:
   name: fluentd
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-logzio
@@ -45,6 +45,9 @@ metadata:
     k8s-app: fluentd-logzio
     version: v1
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logzio
   template:
     metadata:
       labels:

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-logzio
@@ -7,6 +7,9 @@ metadata:
     k8s-app: fluentd-logzio
     version: v1
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logzio
   template:
     metadata:
       labels:


### PR DESCRIPTION
Updated DaemonSet to use the `apps/v1` apiVersion and added the required `selector` to the spec.

This allows logs to be shipped from 1.16 clusters now that `extensions/v1beta1` is deprecated.

Should be backward compatible as the apps/v1 API has been available since v1.9

Tested deployment with logz.io docs and logs are being shipped from the test cluster to logz.io.