### PR TITLE
upgrade fluentd image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.8.1-debian-logzio-1.0
+FROM fluent/fluentd-kubernetes-daemonset:v1.10.4-debian-logzio-1.0
 
 USER root
 WORKDIR /home/fluent

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ By default, latest images launch `prometheus` plugins to monitor fluentd.
 You can disable prometheus input plugin by setting `disable` to `FLUENTD_PROMETHEUS_CONF` environment variable in your kubernetes configuration.
 
 ### Changelog
+- v1.1.1
+  - Upgrade fluentd base image to v.1.10.4
 - v1.1.0
   - Update deprecated conifg
 - v1.0.9

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -61,7 +61,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.0
+        image: logzio/logzio-k8s:1.1.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.0
+        image: logzio/logzio-k8s:1.1.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:


### PR DESCRIPTION
Upgrade logzio-k8s' fluentd base image to newest version (v. 1.10.4).