### PR TITLE
remove wrong ruby version from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
     apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \
                   $buildDeps \
- && rm -rf /var/lib/apt/lists/* \
-           /home/fluent/.gem/ruby/2.3.0/cache/*.gem
+ && rm -rf /var/lib/apt/lists/*
 
 # Copy configuration files
 COPY ./conf/*.conf /fluentd/etc/


### PR DESCRIPTION
Upstream dockerfile uses ruby 2.6, directory in this dockerfile `/home/fluent/.gem/ruby/2.3.0` does not exist in fact, there is nothing inside `/home/fluent` or `/root/.gem`