### PR TITLE
Prevent parsing errors on Non-UTC hosts

### DIFF
--- a/conf/kubernetes-containerd.conf
+++ b/conf/kubernetes-containerd.conf
@@ -14,7 +14,7 @@
   <parse>
     @type regexp
     expression /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
-    time_format %Y-%m-%dT%H:%M:%S.%NZ
+    time_format %Y-%m-%dT%H:%M:%S.%N%z
   </parse>
 </source>
 


### PR DESCRIPTION
This allows for the kubernetes node to not be configured to use UTC.

Instead of looking for a hardcoded Z at the end of the timestamp.. we could parse the timezone instead.. which includes Z for utc. 