### PR TITLE
bump version, fix docker dir, include namespace, exclude fluentd logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.10.4-debian-logzio-1.0
+FROM fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-logzio-1.0
 
 USER root
-WORKDIR /home/fluent
+WORKDIR /fluentd
 
 COPY Gemfile* /fluentd/
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
@@ -14,7 +14,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
                   -o APT::AutoRemove::RecommendsImportant=false \
                   $buildDeps \
  && rm -rf /var/lib/apt/lists/* \
-           /home/fluent/.gem/ruby/2.3.0/cache/*.gem
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
 # Copy configuration files
 COPY ./conf/*.conf /fluentd/etc/
@@ -29,6 +29,7 @@ ENV LOGZIO_FLUSH_INTERVAL "5s"
 ENV LOGZIO_RETRY_MAX_INTERVAL "30"
 ENV LOGZIO_RETRY_FOREVER "true"
 ENV LOGZIO_FLUSH_THREAD_COUNT "2"
+ENV INCLUDE_NAMESPACE ""
 
 # Defaults value for system.conf
 ENV LOGZIO_LOG_LEVEL "info"

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source "https://rubygems.org"
 
-gem "fluentd", "1.10.4"
+gem "fluentd", "1.11.5"
 gem "oj", "3.5.1"
 gem "fluent-plugin-concat"
 gem "fluent-plugin-logzio", "0.0.20"
 gem "fluent-plugin-record-modifier"
-gem "fluent-plugin-detect-exceptions"
+gem "fluent-plugin-detect-exceptions" , ">=0.0.13"
 gem "fluent-plugin-kubernetes_metadata_filter", ">=2.4.2"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Customize the integration environment variables configurations with the paramete
 | LOGZIO_RETRY_MAX_INTERVAL | **Default**: `30s` <br>  Maximum interval, in seconds, to wait between retries. |
 | LOGZIO_FLUSH_THREAD_COUNT | **Default**: `2` <br>  Number of threads to flush the buffer. |
 | LOGZIO_LOG_LEVEL | **Default**: `info` <br> The log level for this container. |
-| INCLUDE_NAMESPACE | **Default**: `""` <br> Use if you wish to send logs from specific k8s namespaces. Should be in the following format: <br> `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. |
+| INCLUDE_NAMESPACE | **Default**: `""` <br> Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: <br> `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. |
 
 #### 3.  Deploy the DaemonSet
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Customize the integration environment variables configurations with the paramete
 | LOGZIO_RETRY_MAX_INTERVAL | **Default**: `30s` <br>  Maximum interval, in seconds, to wait between retries. |
 | LOGZIO_FLUSH_THREAD_COUNT | **Default**: `2` <br>  Number of threads to flush the buffer. |
 | LOGZIO_LOG_LEVEL | **Default**: `info` <br> The log level for this container. |
+| INCLUDE_NAMESPACE | **Default**: `""` <br> Use if you wish to send logs from specific k8s namespaces. Should be in the following format: <br> `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. |
 
 #### 3.  Deploy the DaemonSet
 
@@ -160,6 +161,11 @@ You can disable prometheus input plugin by setting `disable` to `FLUENTD_PROMETH
 
 
 ### Changelog
+- v1.1.5
+  - Bumped Fluentd version to v.1.11.5 (thanks @jeroenzeegers).
+  - Fixed docker image: changed workdir & removed wrong gem path (thanks @pete911).
+  - Configured Fluentd to exclude its own logs.
+  - Allow sending logs from specific k8s namespaces.
 - v1.1.4
   - Add `fluent-plugin-kubernetes_metadata_filter`.
 - v1.1.3

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Customize the integration environment variables configurations with the paramete
 | LOGZIO_RETRY_MAX_INTERVAL | **Default**: `30s` <br>  Maximum interval, in seconds, to wait between retries. |
 | LOGZIO_FLUSH_THREAD_COUNT | **Default**: `2` <br>  Number of threads to flush the buffer. |
 | LOGZIO_LOG_LEVEL | **Default**: `info` <br> The log level for this container. |
-| INCLUDE_NAMESPACE | **Default**: `""` <br> Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: <br> `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. |
+| INCLUDE_NAMESPACE | **Default**: `""`(All namespaces) <br> Use if you wish to send logs from specific k8s namespaces, space delimited. Should be in the following format: <br> `kubernetes.var.log.containers.**_<<NAMESPACE-TO-INCLUDE>>_** kubernetes.var.log.containers.**_<<ANOTHER-NAMESPACE>>_**`. |
 
 #### 3.  Deploy the DaemonSet
 

--- a/conf/fluent.conf
+++ b/conf/fluent.conf
@@ -4,7 +4,7 @@
 @include system.conf
 @include conf.d/*.conf
 
-<match **>
+<match "#{ENV['INCLUDE_NAMESPACE'] || '**'}">
   @type logzio_buffered
   @id out_logzio
   endpoint_url "#{ENV['LOGZIO_LOG_LISTENER']}?token=#{ENV['LOGZIO_LOG_SHIPPING_TOKEN']}"

--- a/conf/kubernetes-containerd.conf
+++ b/conf/kubernetes-containerd.conf
@@ -9,6 +9,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
+  exclude_path /var/log/containers/fluentd*.log
   tag logzio.kubernetes.*
   read_from_head true
   <parse>

--- a/conf/kubernetes.conf
+++ b/conf/kubernetes.conf
@@ -9,6 +9,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
+  exclude_path /var/log/containers/fluentd*.log
   tag logzio.kubernetes.*
   read_from_head true
   <parse>

--- a/conf/system.conf
+++ b/conf/system.conf
@@ -1,10 +1,3 @@
 <system>
   log_level "#{ENV['LOGZIO_LOG_LEVEL']}"
 </system>
-<filter>
-  @type grep
-  <exclude>
-    key message
-    pattern /endpoint_url "https:\/\/listener(([-][a-z]{2})){0,1}.logz.io:8071[?]token=([a-zA-Z]{32})"/
-  </exclude>
-</filter>

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -61,7 +61,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.4
+        image: logzio/logzio-k8s:1.1.5
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
@@ -79,6 +79,8 @@ spec:
           value: "disable"
         - name: FLUENTD_KUBERNETES_CONTAINERD_CONF
           value: "kubernetes-containerd"
+        - name: INCLUDE_NAMESPACE
+          value: ""
         resources:
           limits:
             memory: 200Mi

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -61,7 +61,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.4
+        image: logzio/logzio-k8s:1.1.5
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
@@ -77,6 +77,8 @@ spec:
           value: "disable"
         - name: FLUENTD_PROMETHEUS_CONF
           value: "disable"
+        - name: INCLUDE_NAMESPACE
+          value: ""
         resources:
           limits:
             memory: 200Mi

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.4
+        image: logzio/logzio-k8s:1.1.5
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
@@ -37,6 +37,8 @@ spec:
           value: "disable"
         - name: FLUENTD_PROMETHEUS_CONF
           value: "disable"
+        - name: INCLUDE_NAMESPACE
+          value: ""
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
In this PR:
  - Bumped Fluentd version to latest- v.1.11.5. (As suggested in #59 )
  - Fixed docker image: changed workdir (`/home/fluent` was empty, changed it to `/fluend`) & removed wrong gem path (was pointing to a dir for ruby 2.3 which didn't exist). (As pointed in #56 )
  - Configured Fluentd to exclude its own logs.
  - Allow sending logs from specific k8s namespaces.