### PR TITLE
config via configmaps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
-# Copy configuration files
-COPY ./conf/*.conf /fluentd/etc/
-
 # Default values for fluent.conf
 ENV LOGZIO_BUFFER_TYPE "file"
 ENV LOGZIO_BUFFER_PATH "/var/log/fluentd-buffers/stackdriver.buffer"

--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ You can disable prometheus input plugin by setting `disable` to `FLUENTD_PROMETH
   - Fluentd configuration will be pulled from `configmap.yaml`.
   - Allow changing audit logs format via env var `AUDIT_LOG_FORMAT`.
   - Update API version for RBAC Daemonsets.
-  
+
 **logzio/logzio-k8s:**
+
 This docker image is deprecated. Please use the logzio/logzio-fluentd image instead.
 - v1.1.6
   - Allow changing of SSL configurations.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ You can disable prometheus input plugin by setting `disable` to `FLUENTD_PROMETH
   - Fluentd configuration will be pulled from `configmap.yaml`.
   - Allow changing audit logs format via env var `AUDIT_LOG_FORMAT`.
   - Update API version for RBAC Daemonsets.
+  
 **logzio/logzio-k8s:**
 This docker image is deprecated. Please use the logzio/logzio-fluentd image instead.
 - v1.1.6

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # logzio-k8s
 
 For Kubernetes, a DaemonSet ensures that some or all nodes run a copy of a pod.
@@ -52,18 +53,18 @@ kubectl create secret generic logzio-logs-secret \
 For an RBAC cluster:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-rbac.yaml -f PATH_TO_CONFIG_MAPS
+kubectl apply -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-rbac.yaml -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/configmap.yaml
 ```
 
 Or for a non-RBAC cluster:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset.yaml -f PATH_TO_CONFIG_MAPS
+kubectl apply -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset.yaml -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/configmap.yaml
 ```
 
 For container runtime Containerd:
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-containerd.yaml -f PATH_TO_CONFIG_MAPS
+kubectl apply -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-containerd.yaml -f https://raw.githubusercontent.com/logzio/logzio-k8s/master/configmap.yaml
 ```
 
 #### 4.  Check Logz.io for your logs
@@ -140,7 +141,7 @@ Customize the integration environment variables configurations with the paramete
 | FLUENT_FILTER_KUBERNETES_URL | **Default**: `nil` (doesn't appear in the pre-made Daemonset) <br> URL to the API server. Set this to retrieve further kubernetes metadata for logs from kubernetes API server. If not specified, environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` will be used if both are present which is typically true when running fluentd in a pod. <br> **Please note** that this parameter does NOT appear in the pre-made environment variable list in the Daemonset. If you wish to use & set this variable, you'll have to add it to the Daemonset's environment variables. |
 | AUDIT_LOG_FORMAT | **Default**: `audit` <br> The format of your audit logs. If your audit logs are in json format, set to `audit-json`.  |
 
-If you wish to make any further changes in Fluentd's configuration, download the [configmap file](PATH-TO-CONFIGMAP), open the file in your text editor and make the changes that you need.
+If you wish to make any further changes in Fluentd's configuration, download the [configmap file](https://raw.githubusercontent.com/logzio/logzio-k8s/master/configmap.yaml), open the file in your text editor and make the changes that you need.
 
 
 #### 4.  Deploy the DaemonSet

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ You have two options for deployment:
 * [Custom configuration](#custom-config)
 
 **Important notes:**
-*  If you're running on k8s 1.19.3+, please use `logzio-daemonset-containerd.yaml`.
-* The API version of `ClusterRole` and `ClusterRoleBinding` in `logzio-daemonset-rbac.yaml` and `logzio-daemonset-containerd.yaml` is `v1`, since `v1beta1` was deprecated as of k8s 1.17. If you're running on an earlier k8s version, you may need to manually change the API version for those components.
+*   **K8S 1.19.3+**  - If you’re running on K8S 1.19.3+ or later, be sure to use the DaemonSet that supports a containerd at runtime. It can be downloaded and customized from[`logzio-daemonset-containerd.yaml`](https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-containerd.yaml).
+* **K8S 1.16 or earlier** - If you’re running K8S 1.16 or earlier, you may need to manually change the API version in your DaemonSet to `apiVersion: rbac.authorization.k8s.io/v1beta1`. The API versions of `ClusterRole` and `ClusterRoleBinding` are found in `logzio-daemonset-rbac.yaml` and `logzio-daemonset-containerd.yaml`. If you are running K8S 1.17 or later, the DaemonSet is set to use `apiVersion: rbac.authorization.k8s.io/v1` by default. No change is needed.
+* The latest version pulls the image from `logzio/logzio-fluentd`. Previous versions pulled the image from `logzio/logzio-k8s`.
 
 <div id="default-config">
 
@@ -26,7 +27,7 @@ However, you can deploy a custom configuration if your environment needs it.
 ### To deploy logzio-k8s
 
 #### 1. Create a monitoring namespace
-This is the namespace that the Daemonset will be deployed under.
+Your DaemonSet will be deployed under the namespace `monitoring`.
 
 ```shell
 kubectl create namespace monitoring
@@ -114,15 +115,12 @@ kubectl create secret generic logzio-logs-secret \
 
 #### 3.  Configure Fluentd
 
-Download either
-the [RBAC DaemonSet](https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-rbac.yaml)
-or the [non-RBAC DaemonSet](https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset.yaml)
-or the [containerd Daemonset](https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-containerd.yaml)
-and open the file in your text editor.
+There are 3 DaemonSet options:  [RBAC DaemonSet](https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-rbac.yaml),  [non-RBAC DaemonSet](https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset.yaml),  [Containerd](https://raw.githubusercontent.com/logzio/logzio-k8s/master/logzio-daemonset-containerd.yaml). Download the relevant DaemonSet and open it in your text editor to edit it.
 
-Customize the integration environment variables configurations with the parameters shown below.
+If you wish to make advanced changes in your Fluentd configuration, you can download and edit the  [configmap yaml file](https://raw.githubusercontent.com/logzio/logzio-k8s/master/configmap.yaml).
 
-**Parameters**
+**Environment variables**
+The following environment variables can be edited directly from the DaemonSet without editing the Configmap.
 
 | Parameter | Description |
 |---|---|
@@ -190,7 +188,7 @@ You can disable prometheus input plugin by setting `disable` to `FLUENTD_PROMETH
 - v1.0.0:
   - Fluentd configuration will be pulled from `configmap.yaml`.
   - Allow changing audit logs format via env var `AUDIT_LOG_FORMAT`.
-
+  - Update API version for RBAC Daemonsets.
 **logzio/logzio-k8s:**
 This docker image is deprecated. Please use the logzio/logzio-fluentd image instead.
 - v1.1.6

--- a/configmap.yaml
+++ b/configmap.yaml
@@ -1,0 +1,518 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: monitoring
+  labels:
+    k8s-app: fluentd-logzio
+data:
+  fluent.conf: |
+    @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"
+    @include "#{ENV['FLUENTD_PROMETHEUS_CONF'] || 'prometheus'}.conf"
+    @include "#{ENV['FLUENTD_KUBERNETES_CONTAINERD_CONF'] || 'kubernetes'}.conf"
+    @include system.conf
+    @include conf.d/*.conf
+
+    <match "#{ENV['INCLUDE_NAMESPACE'] || '**'}">
+      @type logzio_buffered
+      @id out_logzio
+      endpoint_url "#{ENV['LOGZIO_LOG_LISTENER']}?token=#{ENV['LOGZIO_LOG_SHIPPING_TOKEN']}"
+      output_include_time true
+      output_include_tags true
+      <buffer>
+        # Set the buffer type to file to improve the reliability and reduce the memory consumption
+        @type "#{ENV['LOGZIO_BUFFER_TYPE']}"
+        path "#{ENV['LOGZIO_BUFFER_PATH']}"
+        # Set queue_full action to block because we want to pause gracefully
+        # in case of the off-the-limits load instead of throwing an exception
+        overflow_action "#{ENV['LOGZIO_OVERFLOW_ACTION']}"
+        # Set the chunk limit conservatively to avoid exceeding the GCL limit
+        # of 10MiB per write request.
+        chunk_limit_size "#{ENV['LOGZIO_CHUNK_LIMIT_SIZE']}"
+        # Cap the combined memory usage of this buffer and the one below to
+        # 2MiB/chunk * (6 + 2) chunks = 16 MiB
+        queue_limit_length "#{ENV['LOGZIO_QUEUE_LIMIT_LENGTH']}"
+        # Never wait more than 5 seconds before flushing logs in the non-error case.
+        flush_interval "#{ENV['LOGZIO_FLUSH_INTERVAL']}"
+        # Never wait longer than 30 seconds between retries.
+        retry_max_interval "#{ENV['LOGZIO_RETRY_MAX_INTERVAL']}"
+        # Disable the limit on the number of retries (retry forever).
+        retry_forever "#{ENV['LOGZIO_RETRY_FOREVER']}"
+        # Use multiple threads for processing.
+        flush_thread_count "#{ENV['LOGZIO_FLUSH_THREAD_COUNT']}"
+      </buffer>
+    </match>
+  kubernetes.conf: |
+    <label @FLUENT_LOG>
+      <match fluent.*>
+        @type null
+      </match>
+    </label>
+
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      exclude_path /var/log/containers/fluentd*.log
+      tag logzio.kubernetes.*
+      read_from_head true
+      <parse>
+        @type json
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_minion
+      path /var/log/salt/minion
+      pos_file /var/log/fluentd-salt.pos
+      tag logzio.salt
+      <parse>
+        @type regexp
+        expression /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
+        time_format %Y-%m-%d %H:%M:%S
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_startupscript
+      path /var/log/startupscript.log
+      pos_file /var/log/fluentd-startupscript.log.pos
+      tag logzio.startupscript
+      <parse>
+        @type syslog
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_docker
+      path /var/log/docker.log
+      pos_file /var/log/fluentd-docker.log.pos
+      tag logzio.docker
+      <parse>
+        @type regexp
+        expression /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_etcd
+      path /var/log/etcd.log
+      pos_file /var/log/fluentd-etcd.log.pos
+      tag logzio.etcd
+      <parse>
+        @type none
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kubelet
+      multiline_flush_interval 5s
+      path /var/log/kubelet.log
+      pos_file /var/log/fluentd-kubelet.log.pos
+      tag logzio.kubelet
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_proxy
+      multiline_flush_interval 5s
+      path /var/log/kube-proxy.log
+      pos_file /var/log/fluentd-kube-proxy.log.pos
+      tag logzio.kube-proxy
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_apiserver
+      multiline_flush_interval 5s
+      path /var/log/kube-apiserver.log
+      pos_file /var/log/fluentd-kube-apiserver.log.pos
+      tag logzio.kube-apiserver
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_controller_manager
+      multiline_flush_interval 5s
+      path /var/log/kube-controller-manager.log
+      pos_file /var/log/fluentd-kube-controller-manager.log.pos
+      tag logzio.kube-controller-manager
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_scheduler
+      multiline_flush_interval 5s
+      path /var/log/kube-scheduler.log
+      pos_file /var/log/fluentd-kube-scheduler.log.pos
+      tag logzio.kube-scheduler
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_rescheduler
+      multiline_flush_interval 5s
+      path /var/log/rescheduler.log
+      pos_file /var/log/fluentd-rescheduler.log.pos
+      tag logzio.rescheduler
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_glbc
+      multiline_flush_interval 5s
+      path /var/log/glbc.log
+      pos_file /var/log/fluentd-glbc.log.pos
+      tag logzio.glbc
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_cluster_autoscaler
+      multiline_flush_interval 5s
+      path /var/log/cluster-autoscaler.log
+      pos_file /var/log/fluentd-cluster-autoscaler.log.pos
+      tag logzio.cluster-autoscaler
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    @include "#{ENV['AUDIT_LOG_FORMAT'] || 'audit'}.conf"
+
+    # This handles multiline exceptions automatically: https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions
+    <match logzio.**>
+      @type detect_exceptions
+      remove_tag_prefix logzio
+      message log
+      languages all
+      multiline_flush_interval 0.1
+    </match>
+
+    # This adds type to the log && change key log to message
+    <filter **>
+      @type record_modifier
+      <record>
+        type  k8s
+        message ${record["log"]}
+      </record>
+      remove_keys log
+    </filter>
+
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+      @id filter_kube_metadata
+      kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || 'https://' + ENV.fetch('KUBERNETES_SERVICE_HOST') + ':' + ENV.fetch('KUBERNETES_SERVICE_PORT') + '/api'}"
+      verify_ssl "#{ENV['KUBERNETES_VERIFY_SSL'] || true}"
+    </filter>
+
+  system.conf: |
+    <system>
+      log_level "#{ENV['LOGZIO_LOG_LEVEL']}"
+    </system>
+
+  systemd.conf: |
+    # Logs from systemd-journal for interesting services.
+    <source>
+      @type systemd
+      @id in_systemd_kubelet
+      filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+      <storage>
+        @type local
+        persistent true
+        path /var/log/fluentd-journald-kubelet-cursor.json
+      </storage>
+      read_from_head true
+      tag kubelet
+    </source>
+
+    # Logs from docker-systemd
+    <source>
+      @type systemd
+      @id in_systemd_docker
+      filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+      <storage>
+        @type local
+        persistent true
+        path /var/log/fluentd-journald-docker-cursor.json
+      </storage>
+      read_from_head true
+      tag docker.systemd
+    </source>
+
+    # Logs from systemd-journal for interesting services.
+    <source>
+      @type systemd
+      @id in_systemd_bootkube
+      filters [{ "_SYSTEMD_UNIT": "bootkube.service" }]
+      <storage>
+        @type local
+        persistent true
+        path /var/log/fluentd-journald-bootkube-cursor.json
+      </storage>
+      read_from_head true
+      tag bootkube
+    </source>
+
+  kubernetes-containerd.conf: |
+    <label @FLUENT_LOG>
+      <match fluent.*>
+        @type null
+      </match>
+    </label>
+
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      exclude_path /var/log/containers/fluentd*.log
+      tag logzio.kubernetes.*
+      read_from_head true
+      <parse>
+        @type regexp
+        expression /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_minion
+      path /var/log/salt/minion
+      pos_file /var/log/fluentd-salt.pos
+      tag logzio.salt
+      <parse>
+        @type regexp
+        expression /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
+        time_format %Y-%m-%d %H:%M:%S
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_startupscript
+      path /var/log/startupscript.log
+      pos_file /var/log/fluentd-startupscript.log.pos
+      tag logzio.startupscript
+      <parse>
+        @type syslog
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_docker
+      path /var/log/docker.log
+      pos_file /var/log/fluentd-docker.log.pos
+      tag logzio.docker
+      <parse>
+        @type regexp
+        expression /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_etcd
+      path /var/log/etcd.log
+      pos_file /var/log/fluentd-etcd.log.pos
+      tag logzio.etcd
+      <parse>
+        @type none
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kubelet
+      multiline_flush_interval 5s
+      path /var/log/kubelet.log
+      pos_file /var/log/fluentd-kubelet.log.pos
+      tag logzio.kubelet
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_proxy
+      multiline_flush_interval 5s
+      path /var/log/kube-proxy.log
+      pos_file /var/log/fluentd-kube-proxy.log.pos
+      tag logzio.kube-proxy
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_apiserver
+      multiline_flush_interval 5s
+      path /var/log/kube-apiserver.log
+      pos_file /var/log/fluentd-kube-apiserver.log.pos
+      tag logzio.kube-apiserver
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_controller_manager
+      multiline_flush_interval 5s
+      path /var/log/kube-controller-manager.log
+      pos_file /var/log/fluentd-kube-controller-manager.log.pos
+      tag logzio.kube-controller-manager
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_kube_scheduler
+      multiline_flush_interval 5s
+      path /var/log/kube-scheduler.log
+      pos_file /var/log/fluentd-kube-scheduler.log.pos
+      tag logzio.kube-scheduler
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_rescheduler
+      multiline_flush_interval 5s
+      path /var/log/rescheduler.log
+      pos_file /var/log/fluentd-rescheduler.log.pos
+      tag logzio.rescheduler
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_glbc
+      multiline_flush_interval 5s
+      path /var/log/glbc.log
+      pos_file /var/log/fluentd-glbc.log.pos
+      tag logzio.glbc
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    <source>
+      @type tail
+      @id in_tail_cluster_autoscaler
+      multiline_flush_interval 5s
+      path /var/log/cluster-autoscaler.log
+      pos_file /var/log/fluentd-cluster-autoscaler.log.pos
+      tag logzio.cluster-autoscaler
+      <parse>
+        @type kubernetes
+      </parse>
+    </source>
+
+    @include "#{ENV['AUDIT_LOG_FORMAT'] || 'audit'}.conf"
+
+    # This handles multiline exceptions automatically: https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions
+    <match logzio.**>
+      @type detect_exceptions
+      remove_tag_prefix logzio
+      message log
+      languages all
+      multiline_flush_interval 0.1
+    </match>
+
+    # This adds type to the log && change key log to message
+    <filter **>
+      @type record_modifier
+      <record>
+        type  k8s
+        message ${record["log"]}
+      </record>
+      remove_keys log
+    </filter>
+
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+      @id filter_kube_metadata
+      kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || 'https://' + ENV.fetch('KUBERNETES_SERVICE_HOST') + ':' + ENV.fetch('KUBERNETES_SERVICE_PORT') + '/api'}"
+      verify_ssl "#{ENV['KUBERNETES_VERIFY_SSL'] || true}"
+    </filter>
+
+  audit.conf: |
+    # Example:
+    # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
+    # 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+    <source>
+      @type tail
+      @id in_tail_kube_apiserver_audit
+      multiline_flush_interval 5s
+      path /var/log/kubernetes/kube-apiserver-audit.log
+      pos_file /var/log/kube-apiserver-audit.log.pos
+      tag logzio.kube-apiserver-audit
+      <parse>
+        @type multiline
+        format_firstline /^\S+\s+AUDIT:/
+        # Fields must be explicitly captured by name to be parsed into the record.
+        # Fields may not always be present, and order may change, so this just looks
+        # for a list of key="\"quoted\" value" pairs separated by spaces.
+        # Unknown fields are ignored.
+        # Note: We can't separate query/response lines as format1/format2 because
+        #       they don't always come one after the other for a given query.
+        format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
+        time_format %Y-%m-%dT%T.%L%Z
+      </parse>
+    </source>
+
+  audit-json.conf: |
+    <source>
+      @type tail
+      @id in_tail_kube_apiserver_audit
+      multiline_flush_interval 5s
+      path /var/log/kubernetes/kube-apiserver-audit.log
+      pos_file /var/log/kube-apiserver-audit.log.pos
+      tag logzio.kube-apiserver-audit
+      <parse>
+        @type json
+        keep_time_key true
+        time_key timestamp
+        time_format %Y-%m-%dT%T.%L%Z
+      </parse>
+    </source>

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fluentd
-  namespace: kube-system
+  namespace: monitoring
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: fluentd
-  namespace: kube-system
+  namespace: monitoring
 rules:
 - apiGroups:
   - ""
@@ -24,7 +24,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fluentd
 roleRef:
@@ -34,13 +34,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: fluentd
-  namespace: kube-system
+  namespace: monitoring
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-logzio
-  namespace: kube-system
+  namespace: monitoring
   labels:
     k8s-app: fluentd-logzio
     version: v1
@@ -59,9 +59,22 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      # Because the image's entrypoint requires to write on /fluentd/etc but we mount configmap there which is read-only,
+      # this initContainers workaround or other is needed.
+      # See https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
+      initContainers:
+        - name: copy-fluentd-config
+          image: busybox
+          command: ['sh', '-c', 'cp /config-volume/..data/* /fluentd/etc']
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: fluentdconf
+              mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.6
+        image: logzio/logzio-fluentd:1.0.0
+        imagePullPolicy: Always
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
@@ -77,12 +90,14 @@ spec:
           value: "disable"
         - name: FLUENTD_PROMETHEUS_CONF
           value: "disable"
-        - name: FLUENTD_KUBERNETES_CONTAINERD_CONF
-          value: "kubernetes-containerd"
         - name: INCLUDE_NAMESPACE
           value: ""
         - name: KUBERNETES_VERIFY_SSL
           value: "true"
+        - name: FLUENTD_KUBERNETES_CONTAINERD_CONF
+          value: "kubernetes-containerd"
+        - name: AUDIT_LOG_FORMAT
+          value: audit
         resources:
           limits:
             memory: 200Mi
@@ -93,8 +108,12 @@ spec:
         - name: varlog
           mountPath: /var/log
         - name: varlibdockercontainers
-          mountPath: /var/log/pods
+          mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: config-volume
+          mountPath: /config-volume
+        - name: fluentdconf
+          mountPath: /fluentd/etc
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog
@@ -102,4 +121,9 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/log/pods
+          path: /var/lib/docker/containers
+      - name: config-volume
+        configMap:
+          name: fluentd-config
+      - name: fluentdconf
+        emptyDir: {}

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fluentd
-  namespace: kube-system
+  namespace: monitoring
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: fluentd
-  namespace: kube-system
+  namespace: monitoring
 rules:
 - apiGroups:
   - ""
@@ -24,7 +24,7 @@ rules:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: fluentd
 roleRef:
@@ -34,13 +34,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: fluentd
-  namespace: kube-system
+  namespace: monitoring
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-logzio
-  namespace: kube-system
+  namespace: monitoring
   labels:
     k8s-app: fluentd-logzio
     version: v1
@@ -59,9 +59,22 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      # Because the image's entrypoint requires to write on /fluentd/etc but we mount configmap there which is read-only,
+      # this initContainers workaround or other is needed.
+      # See https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
+      initContainers:
+        - name: copy-fluentd-config
+          image: busybox
+          command: ['sh', '-c', 'cp /config-volume/..data/* /fluentd/etc']
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: fluentdconf
+              mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.6
+        image: logzio/logzio-fluentd:1.0.0
+        imagePullPolicy: Always
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
@@ -81,6 +94,8 @@ spec:
           value: ""
         - name: KUBERNETES_VERIFY_SSL
           value: "true"
+        - name: AUDIT_LOG_FORMAT
+          value: audit
         resources:
           limits:
             memory: 200Mi
@@ -93,6 +108,10 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: config-volume
+          mountPath: /config-volume
+        - name: fluentdconf
+          mountPath: /fluentd/etc
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog
@@ -101,3 +120,8 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: config-volume
+        configMap:
+          name: fluentd-config
+      - name: fluentdconf
+        emptyDir: {}

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-logzio
-  namespace: kube-system
+  namespace: monitoring
   labels:
     k8s-app: fluentd-logzio
     version: v1
@@ -16,12 +17,27 @@ spec:
         k8s-app: fluentd-logzio
         version: v1
     spec:
+      serviceAccount: fluentd
+      serviceAccountName: fluentd
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      # Because the image's entrypoint requires to write on /fluentd/etc but we mount configmap there which is read-only,
+      # this initContainers workaround or other is needed.
+      # See https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
+      initContainers:
+        - name: copy-fluentd-config
+          image: busybox
+          command: ['sh', '-c', 'cp /config-volume/..data/* /fluentd/etc']
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: fluentdconf
+              mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-k8s:1.1.6
+        image: logzio/logzio-fluentd:1.0.0
+        imagePullPolicy: Always
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:
@@ -41,6 +57,8 @@ spec:
           value: ""
         - name: KUBERNETES_VERIFY_SSL
           value: "true"
+        - name: AUDIT_LOG_FORMAT
+          value: audit
         resources:
           limits:
             memory: 200Mi
@@ -53,6 +71,10 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: config-volume
+          mountPath: /config-volume
+        - name: fluentdconf
+          mountPath: /fluentd/etc
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog
@@ -61,3 +83,8 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: config-volume
+        configMap:
+          name: fluentd-config
+      - name: fluentdconf
+        emptyDir: {}


### PR DESCRIPTION
This PR:
* Changes how fluentd configuration is being used - now the configuration is being pulled from `configmap.yaml`
* Deprecated the `logzio/logzio-k8s` docker image. Now using `logzio/logzio-fluentd` to avoid confusion because of the config change.
* Changes the deployment namespace - from `kube-system` to `monitoring` (Added the creation of this namespace as a step in the documentation).
* As of k8s 1.17+ the `ClusterRole` and `ClusterRoleBinding` api version is `v1` (`v1beta1` is deprecated), so I changed to it in the rbac yamls (logzio-daemonset-rbac, logzio-daemonset-containerd).
* Added env var to change the audit logs format.
* Added a note in the readme - the recommended daemonset for k8s 1.19.3+ is logzio-daemonset-containerd.yaml.
* Changed instructions to match all those changes.

Those changes were tested on:
* AKS - 1.19.3, 1.19.6
* EKS - 1.16