### PR TITLE
update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.11.5-debian-logzio-1.0
+FROM fluent/fluentd-kubernetes-daemonset:v1.13-debian-logzio-amd64-1
 
 USER root
 WORKDIR /fluentd

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "fluentd", "1.11.5"
+gem "fluentd", "1.13.3"
 gem "oj", "3.5.1"
 gem "fluent-plugin-concat"
 gem "fluent-plugin-logzio", "0.0.20"

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ You can disable prometheus input plugin by setting `disable` to `FLUENTD_PROMETH
 
 ### Changelog
 **logzio/logzio-fluentd**:
+- v1.0.1:
+  - Upgrade base image to 'fluent/fluentd-kubernetes-daemonset:v1.13-debian-logzio-amd64-1'.
 - v1.0.0:
   - Fluentd configuration will be pulled from `configmap.yaml`.
   - Allow changing audit logs format via env var `AUDIT_LOG_FORMAT`.

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.0.0
+        image: logzio/logzio-fluentd:1.0.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.0.0
+        image: logzio/logzio-fluentd:1.0.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.0.0
+        image: logzio/logzio-fluentd:1.0.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:


### PR DESCRIPTION
Upgrade Dockerfile's base image to new fluentd version (1.11->1.13).
Update the daemonsets to use the new docker image (1.0.1) + update readme's changelog.
Tests on: AKS (k8s 1.20), EKS (k8s 1.19).