### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The following environment variables can be edited directly from the DaemonSet wi
 | KUBERNETES_VERIFY_SSL | **Default**: `true` <br> Enable to validate SSL certificates. |
 | FLUENT_FILTER_KUBERNETES_URL | **Default**: `nil` (doesn't appear in the pre-made Daemonset) <br> URL to the API server. Set this to retrieve further kubernetes metadata for logs from kubernetes API server. If not specified, environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` will be used if both are present which is typically true when running fluentd in a pod. <br> **Please note** that this parameter does NOT appear in the pre-made environment variable list in the Daemonset. If you wish to use & set this variable, you'll have to add it to the Daemonset's environment variables. |
 | AUDIT_LOG_FORMAT | **Default**: `audit` <br> The format of your audit logs. If your audit logs are in json format, set to `audit-json`.  |
+| CRI | The CRI of the cluster. In `logzio-daemonset` & `logzio-daemonset-rbac` is set to `docker`, and in `logzio-daemonset-containerd` is set to `containerd`. The configmap uses this var to determin which includes it needs to make for the fluent.conf file, when configuration needs to be adjusted by the CRI. |
 
 If you wish to make any further changes in Fluentd's configuration, download the [configmap file](https://raw.githubusercontent.com/logzio/logzio-k8s/master/configmap.yaml), open the file in your text editor and make the changes that you need.
 

--- a/configmap.yaml
+++ b/configmap.yaml
@@ -10,7 +10,7 @@ data:
   fluent.conf: |
     @include "#{ENV['FLUENTD_SYSTEMD_CONF'] || 'systemd'}.conf"
     @include "#{ENV['FLUENTD_PROMETHEUS_CONF'] || 'prometheus'}.conf"
-    @include "#{ENV['FLUENTD_KUBERNETES_CONTAINERD_CONF'] || 'kubernetes'}.conf"
+    @include kubernetes.conf
     @include system.conf
     @include conf.d/*.conf
 
@@ -59,8 +59,21 @@ data:
       tag logzio.kubernetes.*
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type multi_format
+        <pattern>
+          # for docker cri
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+          keep_time_key true
+        </pattern>
+        <pattern>
+          # for containerd cri
+          # format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          format /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+          keep_time_key true
+        </pattern>
       </parse>
     </source>
 
@@ -217,6 +230,8 @@ data:
       languages all
       multiline_flush_interval 0.1
     </match>
+
+    @include "partial-#{ENV['CRI']}.conf"
 
     # This adds type to the log && change key log to message
     <filter **>
@@ -283,199 +298,6 @@ data:
       tag bootkube
     </source>
 
-  kubernetes-containerd.conf: |
-    <label @FLUENT_LOG>
-      <match fluent.*>
-        @type null
-      </match>
-    </label>
-
-    <source>
-      @type tail
-      @id in_tail_container_logs
-      path /var/log/containers/*.log
-      pos_file /var/log/fluentd-containers.log.pos
-      exclude_path /var/log/containers/fluentd*.log
-      tag logzio.kubernetes.*
-      read_from_head true
-      <parse>
-        @type regexp
-        expression /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_minion
-      path /var/log/salt/minion
-      pos_file /var/log/fluentd-salt.pos
-      tag logzio.salt
-      <parse>
-        @type regexp
-        expression /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
-        time_format %Y-%m-%d %H:%M:%S
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_startupscript
-      path /var/log/startupscript.log
-      pos_file /var/log/fluentd-startupscript.log.pos
-      tag logzio.startupscript
-      <parse>
-        @type syslog
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_docker
-      path /var/log/docker.log
-      pos_file /var/log/fluentd-docker.log.pos
-      tag logzio.docker
-      <parse>
-        @type regexp
-        expression /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_etcd
-      path /var/log/etcd.log
-      pos_file /var/log/fluentd-etcd.log.pos
-      tag logzio.etcd
-      <parse>
-        @type none
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kubelet
-      multiline_flush_interval 5s
-      path /var/log/kubelet.log
-      pos_file /var/log/fluentd-kubelet.log.pos
-      tag logzio.kubelet
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_proxy
-      multiline_flush_interval 5s
-      path /var/log/kube-proxy.log
-      pos_file /var/log/fluentd-kube-proxy.log.pos
-      tag logzio.kube-proxy
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_apiserver
-      multiline_flush_interval 5s
-      path /var/log/kube-apiserver.log
-      pos_file /var/log/fluentd-kube-apiserver.log.pos
-      tag logzio.kube-apiserver
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_controller_manager
-      multiline_flush_interval 5s
-      path /var/log/kube-controller-manager.log
-      pos_file /var/log/fluentd-kube-controller-manager.log.pos
-      tag logzio.kube-controller-manager
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_kube_scheduler
-      multiline_flush_interval 5s
-      path /var/log/kube-scheduler.log
-      pos_file /var/log/fluentd-kube-scheduler.log.pos
-      tag logzio.kube-scheduler
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_rescheduler
-      multiline_flush_interval 5s
-      path /var/log/rescheduler.log
-      pos_file /var/log/fluentd-rescheduler.log.pos
-      tag logzio.rescheduler
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_glbc
-      multiline_flush_interval 5s
-      path /var/log/glbc.log
-      pos_file /var/log/fluentd-glbc.log.pos
-      tag logzio.glbc
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    <source>
-      @type tail
-      @id in_tail_cluster_autoscaler
-      multiline_flush_interval 5s
-      path /var/log/cluster-autoscaler.log
-      pos_file /var/log/fluentd-cluster-autoscaler.log.pos
-      tag logzio.cluster-autoscaler
-      <parse>
-        @type kubernetes
-      </parse>
-    </source>
-
-    @include "#{ENV['AUDIT_LOG_FORMAT'] || 'audit'}.conf"
-
-    # This handles multiline exceptions automatically: https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions
-    <match logzio.**>
-      @type detect_exceptions
-      remove_tag_prefix logzio
-      message log
-      languages all
-      multiline_flush_interval 0.1
-    </match>
-
-    # This adds type to the log && change key log to message
-    <filter **>
-      @type record_modifier
-      <record>
-        type  k8s
-        message ${record["log"]}
-      </record>
-      remove_keys log
-    </filter>
-
-    <filter kubernetes.**>
-      @type kubernetes_metadata
-      @id filter_kube_metadata
-      kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || 'https://' + ENV.fetch('KUBERNETES_SERVICE_HOST') + ':' + ENV.fetch('KUBERNETES_SERVICE_PORT') + '/api'}"
-      verify_ssl "#{ENV['KUBERNETES_VERIFY_SSL'] || true}"
-    </filter>
-
   audit.conf: |
     # Example:
     # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
@@ -516,3 +338,27 @@ data:
         time_format %Y-%m-%dT%T.%L%Z
       </parse>
     </source>
+
+  partial-docker.conf: |
+    # Concat docker cri partial log
+    # https://github.com/fluent-plugins-nursery/fluent-plugin-concat
+    # https://github.com/moby/moby/issues/34620#issuecomment-619369707
+    <filter **>
+      @type concat
+      key log
+      use_first_timestamp true
+      multiline_end_regexp /\n$/
+      separator ""
+    </filter>
+
+  partial-containerd.conf: |
+    # Concat containerd cri partial log
+    # https://github.com/fluent/fluentd-kubernetes-daemonset/issues/412#issuecomment-636536767
+    <filter **>
+      @type concat
+      key log
+      use_first_timestamp true
+      partial_key logtag
+      partial_value P
+      separator ""
+    </filter>

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -93,10 +93,10 @@ spec:
           value: ""
         - name: KUBERNETES_VERIFY_SSL
           value: "true"
-        - name: FLUENTD_KUBERNETES_CONTAINERD_CONF
-          value: "kubernetes-containerd"
         - name: AUDIT_LOG_FORMAT
           value: audit
+        - name: CRI
+          value: "containerd"
         resources:
           limits:
             memory: 200Mi

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -95,6 +95,8 @@ spec:
           value: "true"
         - name: AUDIT_LOG_FORMAT
           value: audit
+        - name: "CRI"
+          value: "docker"
         resources:
           limits:
             memory: 200Mi

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -56,6 +56,8 @@ spec:
           value: "true"
         - name: AUDIT_LOG_FORMAT
           value: audit
+        - name: CRI
+          value: "docker"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
- Config refactor:
   - Added multiparser which tries to first parse json (docker cri), and then regex (containerd cri). This allows us to remove the `kubernetes-containerd.conf` file, which is mostly a copy of kubernetes.conf.
   - Added `partial-containerd.conf` and `partial-docker.conf`. Those files contain a filter configuration for concatenating partial logs (when logs are over 16k), for containerd cri & docker cri respectively. The configuration will add the filter, based on the value in env var `CRI` in the damonset.

- Deamonsets refactor:
  - Added new env var `CRI` which indicates the CRI for the damonset. In `logzio-daemonset` & `logzio-daemonset-rbac` it's set to `docker`, and in `logzio-daemonset-containerd` it's set to `containerd`