### PR TITLE
upgrade fluentd, metadata plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.13-debian-logzio-amd64-1
-# to build an arm version, comment the above FROM statement, and uncomment the following line
-# FROM logzio/fluentd-kubernetes-daemonset-arm:v1.13-debian-logzio-arm
+FROM fluent/fluentd-kubernetes-daemonset:v1.14-debian-logzio-amd64-1
 
 USER root
 WORKDIR /fluentd

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,32 @@
+FROM logzio/fluentd-kubernetes-daemonset-arm:v1.14-debian-logzio-arm
+
+USER root
+WORKDIR /fluentd
+
+COPY Gemfile* /fluentd/
+RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends $buildDeps libjemalloc2 \
+ && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
+ && sudo gem sources --clear-all \
+ && SUDO_FORCE_REMOVE=yes \
+    apt-get purge -y --auto-remove \
+                  -o APT::AutoRemove::RecommendsImportant=false \
+                  $buildDeps \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
+
+# Default values for fluent.conf
+ENV LOGZIO_BUFFER_TYPE "file"
+ENV LOGZIO_BUFFER_PATH "/var/log/fluentd-buffers/stackdriver.buffer"
+ENV LOGZIO_OVERFLOW_ACTION "block"
+ENV LOGZIO_CHUNK_LIMIT_SIZE "2M"
+ENV LOGZIO_QUEUE_LIMIT_LENGTH "6"
+ENV LOGZIO_FLUSH_INTERVAL "5s"
+ENV LOGZIO_RETRY_MAX_INTERVAL "30"
+ENV LOGZIO_RETRY_FOREVER "true"
+ENV LOGZIO_FLUSH_THREAD_COUNT "2"
+ENV INCLUDE_NAMESPACE ""
+
+# Defaults value for system.conf
+ENV LOGZIO_LOG_LEVEL "info"

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
 source "https://rubygems.org"
 
-gem "fluentd", "1.13.3"
 gem "oj", "3.5.1"
 gem "fluent-plugin-concat"
 gem "fluent-plugin-logzio", "0.0.20"
 gem "fluent-plugin-record-modifier"
 gem "fluent-plugin-detect-exceptions" , ">=0.0.13"
-gem "fluent-plugin-kubernetes_metadata_filter", ">=2.4.2"
+gem "fluent-plugin-kubernetes_metadata_filter", ">=2.10.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,4 @@
 source "https://rubygems.org"
 
-gem "oj", "3.5.1"
-gem "fluent-plugin-concat"
-gem "fluent-plugin-logzio", "0.0.20"
-gem "fluent-plugin-record-modifier"
-gem "fluent-plugin-detect-exceptions" , ">=0.0.13"
+gem "fluent-plugin-logzio", "0.0.21"
 gem "fluent-plugin-kubernetes_metadata_filter", ">=2.10.0"

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ By default, latest images launch `prometheus` plugins to monitor fluentd. You ca
 
 ### Changelog
 **logzio/logzio-fluentd**:
+- v1.1.0:
+  - Upgrade base image to `v1.14`.
+  - Upgrade `fluent-plugin-kubernetes_metadata_filter` to `2.10`.
 - v1.0.2:
   - The docker image is now available also for ARM architecture.
 - v1.0.1:

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.0.2
+        image: logzio/logzio-fluentd:1.1.0
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.0.2
+        image: logzio/logzio-fluentd:1.1.0
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.0.2
+        image: logzio/logzio-fluentd:1.1.0
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:


### PR DESCRIPTION
This PR:
- Upgrades to fluentd 1.14.6
- Upgrade plugin add_kubernetes_metadata to 2.10.
- Removes redundent gems from Gemfile (as those gems exist already in the base image).
- Creates a seperate Dockerfile for arm arch.