### PR TITLE
upgrade plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "fluent-plugin-logzio", "0.0.21"
-gem "fluent-plugin-kubernetes_metadata_filter", ">=2.10.0"
+gem "fluent-plugin-logzio", "0.0.22"
+gem "fluent-plugin-kubernetes_metadata_filter", ">=2.11.1"

--- a/README.md
+++ b/README.md
@@ -203,16 +203,19 @@ By default, latest images launch `prometheus` plugins to monitor fluentd. You ca
 
 ### Changelog
 **logzio/logzio-fluentd**:
+- v1.1.1:
+  - Upgrade plugin `fluent-plugin-kubernetes_metadata_filter` to `2.11.1`.
+  - upgrade plugin `fluent-plugin-logzio` to `0.0.22`.
 - v1.1.0:
   - Upgrade base image to `v1.14`.
   - Upgrade `fluent-plugin-kubernetes_metadata_filter` to `2.10`.
 - v1.0.2:
   - The docker image is now available also for ARM architecture.
-- v1.0.1:
-  - Upgrade base image to 'fluent/fluentd-kubernetes-daemonset:v1.13-debian-logzio-amd64-1'.
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
+- v1.0.1:
+  - Upgrade base image to 'fluent/fluentd-kubernetes-daemonset:v1.13-debian-logzio-amd64-1'.
 - v1.0.0:
   - Fluentd configuration will be pulled from `configmap.yaml`.
   - Allow changing audit logs format via env var `AUDIT_LOG_FORMAT`.

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.1.0
+        image: logzio/logzio-fluentd:1.1.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.1.0
+        image: logzio/logzio-fluentd:1.1.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.1.0
+        image: logzio/logzio-fluentd:1.1.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:


### PR DESCRIPTION
This PR:
* Upgrades `fluent-plugin-kubernetes_metadata_filter` to `2.11.1` (handles #74 ).
* Upgrade `fluent-plugin-logzio` to `0.0.22`.