### PR TITLE
Fluentd 1.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.16-debian-logzio-amd64-1
+FROM fluent/fluentd-kubernetes-daemonset:v1.16.3-debian-logzio-amd64-1.0
 
 USER root
 WORKDIR /fluentd

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM logzio/fluentd-kubernetes-daemonset-arm:v1.16-debian-logzio-arm
+FROM logzio/fluentd-kubernetes-daemonset-arm:v1.16.3-debian-logzio-arm
 
 USER root
 WORKDIR /fluentd

--- a/README.md
+++ b/README.md
@@ -215,19 +215,22 @@ These templates collects and exposes fluentd metrics on port `24231`, `/metrics`
 
 ### Changelog
 **logzio/logzio-fluentd**:
+
+- **1.5.1**:
+  - Upgrade fluentd to `1.16.3`.
 - **1.5.0**:
   - Upgrade fluentd to 1.16.
   - Upgrade gem `fluent-plugin-logzio` to `0.2.2`:
     - Do not retry on 400 and 401. For 400 - try to fix log and resend.
     - Generate a metric (logzio_status_codes) for response codes from Logz.io.
-- v1.4.0:
-  - Upgrade gem `fluent-plugin-logzio` to `0.1.0`:
-    - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).
 
 
 <details>
   <summary markdown="span"> Expand to check old versions </summary>
 
+- v1.4.0:
+  - Upgrade gem `fluent-plugin-logzio` to `0.1.0`:
+    - Use fluentd's retry instead of retry in code (raise exception on non-2xx response).
 - v1.3.1:
   - Added `fluent-plugin-prometheus`.
   - Added `logzio-daemonset-containerd-monitoring`,  `logzio-daemonset-rbac-monitoring` and `configmap-monitoring.yaml` which exposes fluentd metrics on the pods port `24231`, `/metrics` endpoint

--- a/logzio-daemonset-containerd-monitoring.yaml
+++ b/logzio-daemonset-containerd-monitoring.yaml
@@ -77,7 +77,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.0
+        image: logzio/logzio-fluentd:1.5.1
         ports:
         - name: metrics
           containerPort: 24231

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.0
+        image: logzio/logzio-fluentd:1.5.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset-rbac-monitoring.yaml
+++ b/logzio-daemonset-rbac-monitoring.yaml
@@ -77,7 +77,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.0
+        image: logzio/logzio-fluentd:1.5.1
         ports:
         - name: metrics
           containerPort: 24231

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.0
+        image: logzio/logzio-fluentd:1.5.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.0
+        image: logzio/logzio-fluentd:1.5.1
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:


### PR DESCRIPTION
In this PR:
* Upgrade to use fluent 1.16.3 image.
* Bump image versions in deployments.