### PR TITLE
Updated base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.16.3-debian-logzio-amd64-1.0
+FROM fluent/fluentd-kubernetes-daemonset:v1.16.3-debian-logzio-amd64-2.1
 
 USER root
 WORKDIR /fluentd


### PR DESCRIPTION
The base image fluentd-kubernetes-daemonset:v1.16.3-debian-logzio-amd64-2.1 contain package openssl  3.0.

Reference : https://github.com/fluent/fluentd-docker-image/pull/369