### PR TITLE
[Dev\Release] Upgrade fluentd image version and add supply chain attestations

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -47,7 +47,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.dockeraction.outputs.tags }}-amd
           labels: ${{ steps.dockeraction.outputs.labels }}
-
+          sbom: true
+          provenance: mode=max
 
       - name: Build and push amd64 latest
         uses: docker/build-push-action@v6
@@ -57,6 +58,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: logzio/logzio-fluentd:latest-amd
           labels: ${{ steps.dockeraction.outputs.labels }}
+          sbom: true
+          provenance: mode=max
 
       - name: Build and push arm64 latest
         uses: docker/build-push-action@v6
@@ -67,6 +70,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: logzio/logzio-fluentd:latest-arm
           labels: ${{ steps.dockeraction.outputs.labels }}
+          sbom: true
+          provenance: mode=max
 
       - name: Build and push arm64
         uses: docker/build-push-action@v6
@@ -77,6 +82,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.dockeraction.outputs.tags }}-arm
           labels: ${{ steps.dockeraction.outputs.labels }}
+          sbom: true
+          provenance: mode=max
 
       - name: Create manifest version
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd-kubernetes-daemonset:v1.18.0-debian-logzio-amd64-1.0
+FROM fluent/fluentd-kubernetes-daemonset:v1.18.0-debian-logzio-amd64-1.3
 
 USER root
 WORKDIR /fluentd

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM logzio/fluentd-kubernetes-daemonset-arm:v1.18.0-debian-logzio-arm64-1.0
+FROM fluent/fluentd-kubernetes-daemonset:v1.18.0-debian-logzio-arm64-1.3
 
 USER root
 WORKDIR /fluentd

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ These templates collects and exposes fluentd metrics on port `24231`, `/metrics`
 
 ### Changelog
 **logzio/logzio-fluentd**:
+- **1.5.6**:
+  - Upgrade amd image to `v1.18.0-debian-logzio-amd64-1.3`.
+  - Upgrade arm image to `v1.18.0-debian-logzio-arm64-1.3`.
 - **1.5.5**:
   - Upgrade amd image to `v1.18.0-debian-logzio-amd64-1.0`.
   - Upgrade arm image to `v1.18.0-debian-logzio-arm64-1.0`.

--- a/logzio-daemonset-containerd-monitoring.yaml
+++ b/logzio-daemonset-containerd-monitoring.yaml
@@ -77,7 +77,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.5
+        image: logzio/logzio-fluentd:1.5.6
         ports:
         - name: metrics
           containerPort: 24231

--- a/logzio-daemonset-containerd.yaml
+++ b/logzio-daemonset-containerd.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.5
+        image: logzio/logzio-fluentd:1.5.6
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset-rbac-monitoring.yaml
+++ b/logzio-daemonset-rbac-monitoring.yaml
@@ -77,7 +77,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.5
+        image: logzio/logzio-fluentd:1.5.6
         ports:
         - name: metrics
           containerPort: 24231

--- a/logzio-daemonset-rbac.yaml
+++ b/logzio-daemonset-rbac.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.5
+        image: logzio/logzio-fluentd:1.5.6
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:

--- a/logzio-daemonset.yaml
+++ b/logzio-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /fluentd/etc
       containers:
       - name: fluentd
-        image: logzio/logzio-fluentd:1.5.5
+        image: logzio/logzio-fluentd:1.5.6
         env:
         - name: LOGZIO_LOG_SHIPPING_TOKEN
           valueFrom:


### PR DESCRIPTION
## Description 

this pr resolves #102

- add supply chain attestations
- Upgrade fluentd image version to 1.18.0-1.3

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
